### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
 * @kinde-oss/giants-kinde
+build.gradle.kts @kinde-oss/sdk-engineers
+**/build.gradle.kts @kinde-oss/sdk-engineers
+build.gradle.kts @kinde-oss/sdk-engineers
+**/build.gradle.kts @kinde-oss/sdk-engineers
+build.gradle @kinde-oss/sdk-engineers
+**/build.gradle @kinde-oss/sdk-engineers
+build.gradle @kinde-oss/sdk-engineers
+**/build.gradle @kinde-oss/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.